### PR TITLE
Implement flow statistics query

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -f .coverage
 	rm -fr htmlcov/
 	rm -fr .pytest_cache
+	rm -fr tests/cassettes/
 
 lint: ## check style with flake8 and pylint
 	flake8 streamstats tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 geopy==1.17.0
 requests==2.20.0
+urllib3

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['geopy', 'requests']
+requirements = ['geopy', 'requests', 'urllib3']
 
 setup_requirements = ['pytest-runner', ]
 

--- a/streamstats/utils.py
+++ b/streamstats/utils.py
@@ -1,7 +1,37 @@
 # -*- coding: utf-8 -*-
 """Utility functions for streamstats."""
 
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
 import geopy
+
+
+# https://www.peterbe.com/plog/best-practice-with-retries-with-requests
+def requests_retry_session(retries=3,
+                           backoff_factor=0.3,
+                           status_forcelist=(500, 502, 504)):
+    """Make a session that backs off automatically.
+    :param retries: Number of times to retry a request
+    :type retries: int
+    :param backoff_factor: Relates to the amount of time to wait between
+        requests: {backoff factor} * (2 ^ ({number of total retries} - 1))
+    :type backoff_factor: float
+    :param status_forcelist: Status codes that prompt a retry
+    :type status_forcelist: tuple of ints
+    """
+    session = requests.Session()
+    retry = Retry(
+        total=retries,
+        read=retries,
+        connect=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session
 
 
 def find_address(lat, lon):

--- a/streamstats/watershed.py
+++ b/streamstats/watershed.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Functionality for finding watershed information for specific locations."""
 
-import requests
 from streamstats import utils
 
 
@@ -15,7 +14,6 @@ class Watershed():
     characteristics and flow statistics can also be extracted from watersheds.
     """
     base_url = "https://streamstats.usgs.gov/streamstatsservices/"
-    url = "".join((base_url, "watershed.geojson"))
 
     def __init__(self, lat, lon):
         """Initialize a Watershed object
@@ -29,8 +27,10 @@ class Watershed():
         """
         self.lat, self.lon = lat, lon
         self.address = utils.find_address(lat=lat, lon=lon)
+        self.state = utils.find_state(self.address)
         self.data = self._delineate()
         self.workspace = self.data['workspaceID']
+        self.flowstats = None
 
     def _delineate(self):
         """Find the watershed that contains a point.
@@ -41,7 +41,7 @@ class Watershed():
         :rtype dict containing watershed data
         """
         payload = {
-            'rcode': utils.find_state(self.address),
+            'rcode': self.state,
             'xlocation': self.lon,
             'ylocation': self.lat,
             'crs': 4326,
@@ -50,7 +50,8 @@ class Watershed():
             'includefeatures': True,
             'simplify': False
         }
-        response = requests.get(self.url, params=payload)
+        url = "".join((self.base_url, "watershed.geojson"))
+        response = utils.requests_retry_session().get(url, params=payload)
         response.raise_for_status()  # raises errors early
         return response.json()
 
@@ -80,9 +81,26 @@ class Watershed():
         raise NotImplementedError()
 
     def available_flow_stats(self):
-        """List the available flow statistics"""
-        raise NotImplementedError()
+        """List the available flow statistics
+
+        :rtype list of available flow statistics
+        """
+        if not self.flowstats:
+            self.get_flow_stats()
+        avail_stats = [item['StatisticGroupName'] for item in self.flowstats]
+        return avail_stats
 
     def get_flow_stats(self):
-        """Get watershed flow statistics data values."""
-        raise NotImplementedError()
+        """Get watershed flow statistics data values.
+
+        :rtype dict containing flow statistics data for a watershed
+        """
+        pars = {
+            'rcode': self.state,
+            'workspaceID': self.workspace,
+            'includeflowtypes': True
+        }
+        flow_url = "".join((self.base_url, 'flowstatistics.json'))
+        response = utils.requests_retry_session().get(flow_url, params=pars)
+        self.flowstats = response.json()
+        return self.flowstats

--- a/tests/test_watershed.py
+++ b/tests/test_watershed.py
@@ -13,7 +13,7 @@ class WatershedUnitTests(VCRTestCase):
     '''
 
     @staticmethod
-    def test_find_watershed():
+    def test_watershed():
         """Verify that the JSON response contains expected keys."""
         wshed = Watershed(lat=43.939, lon=-74.524)
         keys = wshed.data.keys()
@@ -24,3 +24,16 @@ class WatershedUnitTests(VCRTestCase):
         assert '04150305' in str(wshed)
         assert str(wshed.lat) in str(wshed)
         assert str(wshed.lon) in str(wshed)
+
+    @staticmethod
+    def test_flow_stats():
+        """Verify that we get the expected flow statistics"""
+        wshed = Watershed(lat=43.939, lon=-74.524)
+        stats = wshed.get_flow_stats()
+        assert stats[0].keys() == stats[1].keys()
+
+        available_stats = wshed.available_flow_stats()
+        assert len(available_stats) == 2
+        assert len(stats) == len(available_stats)
+        assert 'Peak-Flow Statistics' in available_stats
+        assert 'Bankfull Statistics' in available_stats


### PR DESCRIPTION
This allows users to get flow statistics for watersheds. To implement
this, I had to "borrow" an implementation for request retries to handle
the fact that watershed flow statistics are not immediately available
for newly delineated watersheds.